### PR TITLE
Add comeonin to Application

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -15,7 +15,7 @@ defmodule Passport.Mixfile do
   #
   # Type `mix help compile.app` for more information
   def application do
-    [applications: [:logger]]
+    [applications: [:logger, :comeonin]]
   end
 
   defp package do


### PR DESCRIPTION
Add comeonin to application. If you deploy passport using exrm your production environment, it is missing the Comeonin depedency, causing your application to fail.