### PR TITLE
Conflicting Passport.Password module

### DIFF
--- a/lib/passport/password.ex
+++ b/lib/passport/password.ex
@@ -1,5 +1,0 @@
-defmodule Passport.Password do
-  def hash(password) do
-    Comeonin.Bcrypt.hashpwsalt(password)
-  end
-end


### PR DESCRIPTION
Redundant definition of Passport.Password after Phoenix 1.3 rewrite. All functionality already present in lib/passport/auth_type/password/password.ex